### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.1.1][1.1.1]
 ### Removed
 - `VERSION.scad`
 ### Added
@@ -8,11 +10,11 @@
 ### Changed
 - Updated examples
 
-## [1.1.0]
+## [1.1.0][1.1.0]
 ### Added
 - 1.0.0 Positioning of two or more meshing pinions
 
-## [1.0.0]
+## [1.0.0][1.0.0]
 ### Performance
 - Reduced computations when generating pinions
 ### Added
@@ -34,6 +36,7 @@
 
 [Unreleased]: https://github.com/jarirepo/OpenSCAD_SpurGear/tree/dev
 
+[1.1.1]: https://github.com/jarirepo/OpenSCAD_SpurGear/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jarirepo/OpenSCAD_SpurGear/compare/1.0.0...v1.1.0
 [1.0.0]: https://github.com/jarirepo/OpenSCAD_SpurGear/compare/v0.2.1...1.0.0
 [0.2.1]: https://github.com/jarirepo/OpenSCAD_SpurGear/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Removed
+- `VERSION.scad`
+### Added
+- Function `spurgear_required` included in `src/version.scad` that should be used to make assertion on `SpurGear` library version
+### Changed
+- Updated examples
 
 ## [1.1.0]
 ### Added

--- a/SpurGear.scad
+++ b/SpurGear.scad
@@ -1,3 +1,4 @@
+include <src/version.scad>
 include <src/prop_helpers.scad>
 include <src/spur_gear_init.scad>
 include <src/spur_gear_pinion.scad>

--- a/examples/GearRacks.scad
+++ b/examples/GearRacks.scad
@@ -1,4 +1,5 @@
 use <../SpurGear.scad>
+assert(spurgear_required([1, 0, 0]), "Please upgrade SpurGear library to version 1.0.0 or higher");
 
 module GearRacks() {
   gear = spur_gear_init(z = 16, m = 0.75, alpha = 20.0);

--- a/examples/PinionWithIndendation.scad
+++ b/examples/PinionWithIndendation.scad
@@ -1,4 +1,5 @@
 use <../SpurGear.scad>
+assert(spurgear_required([1, 0, 0]), "Please upgrade SpurGear library to version 1.0.0 or higher");
 
 module PinionWithIndendation() {
   gear = spur_gear_init(z = 16, m = 0.75, alpha = 20.0);

--- a/examples/Pinion_Pinion_Positioning.scad
+++ b/examples/Pinion_Pinion_Positioning.scad
@@ -1,4 +1,5 @@
 use <../SpurGear.scad>
+assert(spurgear_required([1, 1, 0]), "Please upgrade SpurGear library to version 1.1.0 or higher");
 
 /**
   This example shows how to properly align three meshing spur gear pinions

--- a/src/spur_gear_init.scad
+++ b/src/spur_gear_init.scad
@@ -1,4 +1,3 @@
-include <../VERSION.scad>
 include <constants.scad>
 include <prop_helpers.scad>
 include <geom_helpers.scad>
@@ -49,5 +48,4 @@ function spur_gear_init(z, m, alpha) =
   ["Dp", Dp],
   ["Dr", Dr],
   ["P", P],
-  ["ver", VERSION],
 ];

--- a/src/version.scad
+++ b/src/version.scad
@@ -1,0 +1,5 @@
+SPURGEAR_SEMVER = [1, 1, 1];
+
+function spurgear_required(ver) =
+  assert(len(ver) == 3, "Version array must have three semantic version elements")
+  SPURGEAR_SEMVER[0] >= ver[0] && SPURGEAR_SEMVER[1] >= ver[1] && SPURGEAR_SEMVER[2] >= ver[2];


### PR DESCRIPTION
Function `spurgear_required` included in `src/version.scad` that should be used to make assertion on `SpurGear` library
